### PR TITLE
Add Hebrew (he) translation + externalize hardcoded ACP strings

### DIFF
--- a/languages/en-GB/openai.json
+++ b/languages/en-GB/openai.json
@@ -1,5 +1,23 @@
 {
 	"error.need-x-reputation-to-mention": "You need at least %1 reputation for mentioning chatgpt",
 	"summarize-topic": "Summarize Topic",
-	"topic-summary": "Topic Summary"
+	"topic-summary": "Topic Summary",
+
+	"admin.general": "General",
+	"admin.apikey": "API Key",
+	"admin.apikey-help": "Get your <a href=\"https://platform.openai.com/api-keys\">API Key</a> and enter it above. You can enter a Google Gemini API key if you want to use Google Gemini. Don't forget to change the model used to a gemini variant. Requires a restart.",
+	"admin.api-base-url": "API Base Url",
+	"admin.api-base-url-help": "If you want to use Google's Gemini API, enter the base URL here (https://generativelanguage.googleapis.com/v1beta/openai/). Otherwise, leave it blank to use OpenAI's API. Requires a restart.",
+	"admin.chatgpt-username": "ChatGPT Username",
+	"admin.chatgpt-username-help": "<a href=\"%1/admin/manage/users\">Create a user</a> and enter their username. Other users can mention this user to ask questions to ChatGPT or send private messages if enabled below.",
+	"admin.enable-private-messages": "Enable Private Messages",
+	"admin.enable-private-messages-help": "If enabled users can send ChatGPT user private messages.",
+	"admin.model": "Model",
+	"admin.system-prompt": "System Prompt",
+	"admin.system-prompt-placeholder": "You are a helpful assistant",
+	"admin.restrictions": "Restrictions",
+	"admin.minimum-reputation": "Minimum Reputation",
+	"admin.minimum-reputation-help": "Minimum reputation required to mention chatgpt user. (0 to disable)",
+	"admin.allowed-groups": "Allowed Groups",
+	"admin.allowed-groups-help": "Only users in these groups will be able to mention the chatgpt user. Leave blank to allow all groups."
 }

--- a/languages/en-US/openai.json
+++ b/languages/en-US/openai.json
@@ -1,5 +1,23 @@
 {
 	"error.need-x-reputation-to-mention": "You need at least %1 reputation for mentioning chatgpt",
 	"summarize-topic": "Summarize Topic",
-	"topic-summary": "Topic Summary"
+	"topic-summary": "Topic Summary",
+
+	"admin.general": "General",
+	"admin.apikey": "API Key",
+	"admin.apikey-help": "Get your <a href=\"https://platform.openai.com/api-keys\">API Key</a> and enter it above. You can enter a Google Gemini API key if you want to use Google Gemini. Don't forget to change the model used to a gemini variant. Requires a restart.",
+	"admin.api-base-url": "API Base Url",
+	"admin.api-base-url-help": "If you want to use Google's Gemini API, enter the base URL here (https://generativelanguage.googleapis.com/v1beta/openai/). Otherwise, leave it blank to use OpenAI's API. Requires a restart.",
+	"admin.chatgpt-username": "ChatGPT Username",
+	"admin.chatgpt-username-help": "<a href=\"%1/admin/manage/users\">Create a user</a> and enter their username. Other users can mention this user to ask questions to ChatGPT or send private messages if enabled below.",
+	"admin.enable-private-messages": "Enable Private Messages",
+	"admin.enable-private-messages-help": "If enabled users can send ChatGPT user private messages.",
+	"admin.model": "Model",
+	"admin.system-prompt": "System Prompt",
+	"admin.system-prompt-placeholder": "You are a helpful assistant",
+	"admin.restrictions": "Restrictions",
+	"admin.minimum-reputation": "Minimum Reputation",
+	"admin.minimum-reputation-help": "Minimum reputation required to mention chatgpt user. (0 to disable)",
+	"admin.allowed-groups": "Allowed Groups",
+	"admin.allowed-groups-help": "Only users in these groups will be able to mention the chatgpt user. Leave blank to allow all groups."
 }

--- a/languages/he/openai.json
+++ b/languages/he/openai.json
@@ -1,0 +1,5 @@
+{
+	"error.need-x-reputation-to-mention": "דרושה לך מוניטין של %1 לפחות כדי לאזכר את chatgpt",
+	"summarize-topic": "סכם נושא",
+	"topic-summary": "סיכום הנושא"
+}

--- a/languages/he/openai.json
+++ b/languages/he/openai.json
@@ -1,5 +1,23 @@
 {
 	"error.need-x-reputation-to-mention": "דרושה לך מוניטין של %1 לפחות כדי לאזכר את chatgpt",
 	"summarize-topic": "סכם נושא",
-	"topic-summary": "סיכום הנושא"
+	"topic-summary": "סיכום הנושא",
+
+	"admin.general": "כללי",
+	"admin.apikey": "מפתח API",
+	"admin.apikey-help": "השג את <a href=\"https://platform.openai.com/api-keys\">מפתח ה-API</a> שלך והזן אותו למעלה. ניתן להזין מפתח API של Google Gemini אם ברצונך להשתמש ב-Google Gemini. אל תשכח לשנות את המודל שבשימוש לגרסת gemini. דורש הפעלה מחדש.",
+	"admin.api-base-url": "כתובת בסיס של API",
+	"admin.api-base-url-help": "אם ברצונך להשתמש ב-API של Google Gemini, הזן כאן את כתובת הבסיס (https://generativelanguage.googleapis.com/v1beta/openai/). אחרת, השאר ריק כדי להשתמש ב-API של OpenAI. דורש הפעלה מחדש.",
+	"admin.chatgpt-username": "שם משתמש של ChatGPT",
+	"admin.chatgpt-username-help": "<a href=\"%1/admin/manage/users\">צור משתמש</a> והזן את שם המשתמש שלו. משתמשים אחרים יוכלו לאזכר את המשתמש הזה כדי לשאול שאלות את ChatGPT, או לשלוח הודעות פרטיות אם הדבר מאופשר למטה.",
+	"admin.enable-private-messages": "אפשר הודעות פרטיות",
+	"admin.enable-private-messages-help": "אם מאופשר, משתמשים יוכלו לשלוח הודעות פרטיות למשתמש ChatGPT.",
+	"admin.model": "מודל",
+	"admin.system-prompt": "הנחיית מערכת",
+	"admin.system-prompt-placeholder": "אתה עוזר מועיל",
+	"admin.restrictions": "הגבלות",
+	"admin.minimum-reputation": "מוניטין מזערי",
+	"admin.minimum-reputation-help": "המוניטין המזערי הנדרש כדי לאזכר את משתמש chatgpt. (0 לביטול)",
+	"admin.allowed-groups": "קבוצות מורשות",
+	"admin.allowed-groups-help": "רק משתמשים בקבוצות אלו יוכלו לאזכר את משתמש chatgpt. השאר ריק כדי לאפשר לכל הקבוצות."
 }

--- a/public/lib/main.js
+++ b/public/lib/main.js
@@ -21,7 +21,7 @@ $('document').ready(function () {
 				size: 'large',
 				buttons: {
 					ok: {
-						label: 'OK',
+						label: '[[global:ok]]',
 						className: 'btn-primary',
 					},
 				},

--- a/templates/admin/plugins/openai.tpl
+++ b/templates/admin/plugins/openai.tpl
@@ -5,43 +5,43 @@
 		<div id="spy-container" class="col-12 col-md-8 px-0 mb-4" tabindex="0">
 			<form role="form" class="openai-settings">
 				<div class="mb-4">
-					<h5 class="fw-bold tracking-tight settings-header">General</h5>
+					<h5 class="fw-bold tracking-tight settings-header">[[openai:admin.general]]</h5>
 
 					<div class="mb-3">
-						<label class="form-label" for="apikey">API Key</label>
-						<input type="text" id="apikey" name="apikey" title="API Key" class="form-control">
+						<label class="form-label" for="apikey">[[openai:admin.apikey]]</label>
+						<input type="text" id="apikey" name="apikey" title="[[openai:admin.apikey]]" class="form-control">
 						<p class="form-text">
-							Get your <a href="https://platform.openai.com/api-keys">API Key</a> and enter it above. You can enter a Google Gemini API key if you want to use Google Gemini. Don't forget to change the model used to a gemini variant. Requires a restart.
+							[[openai:admin.apikey-help]]
 						</p>
 					</div>
 
 					<div class="mb-3">
-						<label class="form-label" for="apiBaseUrl">API Base Url</label>
-						<input type="text" id="apiBaseUrl" name="apiBaseUrl" title="API Base Url" class="form-control">
+						<label class="form-label" for="apiBaseUrl">[[openai:admin.api-base-url]]</label>
+						<input type="text" id="apiBaseUrl" name="apiBaseUrl" title="[[openai:admin.api-base-url]]" class="form-control">
 						<p class="form-text">
-							If you want to use Google's Gemini API, enter the base URL here (https://generativelanguage.googleapis.com/v1beta/openai/). Otherwise, leave it blank to use OpenAI's API. Requires a restart.
+							[[openai:admin.api-base-url-help]]
 						</p>
 					</div>
 
 					<div class="mb-3">
-						<label class="form-label" for="chatgpt-username">ChatGPT Username</label>
-						<input type="text" id="chatgpt-username" name="chatgpt-username" title="ChatGPT Username" class="form-control">
+						<label class="form-label" for="chatgpt-username">[[openai:admin.chatgpt-username]]</label>
+						<input type="text" id="chatgpt-username" name="chatgpt-username" title="[[openai:admin.chatgpt-username]]" class="form-control">
 						<p class="form-text">
-							<a href="{config.relative_path}/admin/manage/users">Create a user</a> and enter their username. Other users can mention this user to ask questions to ChatGPT or send private messages if enabled below.
+							[[openai:admin.chatgpt-username-help, {config.relative_path}]]
 						</p>
 					</div>
 
 					<div class="form-check form-switch">
 						<input type="checkbox" class="form-check-input" id="enablePrivateMessages" name="enablePrivateMessages">
-						<label for="enablePrivateMessages" class="form-check-label">Enable Private Messages</label>
+						<label for="enablePrivateMessages" class="form-check-label">[[openai:admin.enable-private-messages]]</label>
 						<p class="form-text">
-							If enabled users can send ChatGPT user private messages.
+							[[openai:admin.enable-private-messages-help]]
 						</p>
 					</div>
 
 					<div class="mb-3">
-						<label class="form-label" for="model">Model</label>
-						<select class="form-select" id="model" name="model" title="Model">
+						<label class="form-label" for="model">[[openai:admin.model]]</label>
+						<select class="form-select" id="model" name="model" title="[[openai:admin.model]]">
 							<option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
 							<option value="gpt-4o-mini">gpt-4o-mini</option>
 							<option value="gpt-4o">gpt-4o</option>
@@ -53,30 +53,30 @@
 						</select>
 					</div>
 					<div class="">
-						<label class="form-label" for="systemPrompt">System Prompt</label>
-						<textarea class="form-control" id="systemPrompt" name="systemPrompt" title="System prompt" placeholder="You are a helpful assistant" rows="8"></textarea>
+						<label class="form-label" for="systemPrompt">[[openai:admin.system-prompt]]</label>
+						<textarea class="form-control" id="systemPrompt" name="systemPrompt" title="[[openai:admin.system-prompt]]" placeholder="[[openai:admin.system-prompt-placeholder]]" rows="8"></textarea>
 					</div>
 				</div>
 
 				<div class="">
-					<h5 class="fw-bold tracking-tight settings-header">Restrictions</h5>
+					<h5 class="fw-bold tracking-tight settings-header">[[openai:admin.restrictions]]</h5>
 
 					<div class="mb-3">
-						<label class="form-label" for="minimumReputation">Minimum Reputation</label>
-						<input type="text" id="minimumReputation" name="minimumReputation" title="Minimum Reputation" class="form-control">
+						<label class="form-label" for="minimumReputation">[[openai:admin.minimum-reputation]]</label>
+						<input type="text" id="minimumReputation" name="minimumReputation" title="[[openai:admin.minimum-reputation]]" class="form-control">
 						<p class="form-text">
-							Minimum reputation required to mention chatgpt user. (0 to disable)
+							[[openai:admin.minimum-reputation-help]]
 						</p>
 					</div>
 					<div class="mb-3">
-						<label class="form-label" form="allowedGroups">Allowed Groups</label>
+						<label class="form-label" form="allowedGroups">[[openai:admin.allowed-groups]]</label>
 						<select class="form-select" multiple id="allowedGroups" name="allowedGroups" size="10">
 							{{{ each groups }}}
 							<option value="{./displayName}">{./displayName}</option>
 							{{{ end }}}
 						</select>
 						<p class="form-text">
-							Only users in these groups will be able to mention the chatgpt user. Leave blank to allow all groups.
+							[[openai:admin.allowed-groups-help]]
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
## What

- Adds a Hebrew (`he`) translation under `languages/he/openai.json`.
- Externalizes the previously hardcoded English strings in the ACP settings template (`templates/admin/plugins/openai.tpl`) into `[[openai:admin.*]]` translation keys — section headers, labels, input titles, help texts and the system-prompt placeholder.
- Replaces the hardcoded `OK` button label in `public/lib/main.js` with the built-in `[[global:ok]]`.
- Adds the new English keys to both `en-GB` and `en-US`, and full Hebrew values to `he`.

## Notes

- The "Create a user" help link keeps `{config.relative_path}` by passing it as `%1` to `[[openai:admin.chatgpt-username-help, ...]]`, so the link still resolves correctly after translation.
- Model option values (e.g. `gpt-4o`) are identifiers and intentionally left untranslated.